### PR TITLE
interval to spread calls to cloud admin host

### DIFF
--- a/glances/__main__.py
+++ b/glances/__main__.py
@@ -23,7 +23,14 @@
 # Execute with:
 # $ python -m glances (2.7+)
 
+import time
+import random
 import glances
 
 if __name__ == '__main__':
+    # Problem: Imagine There are 1000 server called at the same time (same config on all instances).
+    # Here we want to randomly slow down start program
+    server_start_interval = random.randint(0, 59)
+    time.sleep(server_start_interval)
+    # End solution for problem
     glances.main()


### PR DESCRIPTION
#### interval to spread calls to cloud admin host

customer 1 has 60 servers
customer 1 decides to install this on all 60 servers
every minute at exactly 15 seconds
we get 60 calls into our API
instead of
1 per second over 60 seconds
for the 60 servers

we want to fix this


* Bug fix: no
* New feature: yes
* Fixed tickets: no
