### PR TITLE
drop 3.3 since EOL was 2017

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ add new plugins or exports modules.
 Requirements
 ============
 
-- ``python 2.7,>=3.3``
+- ``python 2.7,>=3.4``
 - ``psutil>=2.0.0`` (better with latest version)
 
 Optional dependencies:


### PR DESCRIPTION
#### Description

Drop Python 3.3 support from README, as EOL was in EOY 2017.
